### PR TITLE
Update of initiation external data source med_spec_loop_v3.py

### DIFF
--- a/med_spec_loop_v3.py
+++ b/med_spec_loop_v3.py
@@ -183,12 +183,12 @@ if data_source!='local':
         t_start = inv[0][0].start_date
     else:
         t_start = UTCDateTime(config['DEFAULT']['t_start']) # use start time specified in parser file
-        inv[0][0][0].start_date = t_start
+    inv[0][0][0].start_date = t_start
     if not t_end:
         t_end =  inv[0][0].end_date
     else:
         t_end = UTCDateTime(config['DEFAULT']['t_end']) # use end time specified in parser file 
-        inv[0][0][0].end_date = t_end
+    inv[0][0][0].end_date = t_end
         
      
     # Read in and remove instrument response from first day

--- a/med_spec_loop_v3.py
+++ b/med_spec_loop_v3.py
@@ -176,12 +176,27 @@ if data_source!='local':
     # READ IN FROM FDSN CLIENT
     inv = fdsn_client.get_stations(network=network, station=station, channel=channel, 
                                    location='', level="response")
-    t_start = inv[0][0].start_date
-    t_end = inv[0][0].end_date
-    
+  
+    # start/end dates: read the dates specified in the parser file, even when getting data from external source. 
+    # if the start/end dates are left empty in the parser file, read the full extent of available data at the external source. 
+    if not t_start:
+        t_start = inv[0][0].start_date
+    else:
+        t_start = UTCDateTime(config['DEFAULT']['t_start']) # use start time specified in parser file
+        inv[0][0][0].start_date = t_start
+    if not t_end:
+        t_end =  inv[0][0].end_date
+    else:
+        t_end = UTCDateTime(config['DEFAULT']['t_end']) # use end time specified in parser file 
+        inv[0][0][0].end_date = t_end
+        
+     
     # Read in and remove instrument response from first day
     st = fdsn_client.get_waveforms(network=network, station=station, location='',
                                    channel=channel, starttime=t_start, endtime=t_start+86400)
+    
+    # initiate token file counter
+    file_counter = 0 
 
 
 #sys.quit()


### PR DESCRIPTION
Changes on line 180-191: should allow the user to specify start and end times even when working with data from external source. When t_start and t_end are left as empty strings ('') in the par file, reads entire available temporal extent given by the response file. 
Change on line 198-199: initiates the file_counter variable in instances where the data source is external as well.